### PR TITLE
feat: Add missing intro movie events.

### DIFF
--- a/shared/events.d.ts
+++ b/shared/events.d.ts
@@ -46,6 +46,8 @@ interface GlobalEventNameMap {
 	'AsyncEvent':						(delay: duration, eventToFire: string) => void,
 	'ChaosHudProcessInput':				() => void,
 	'ChaosHudThink':					() => void,
+	'ChaosShowIntroMovie':				() => void,
+	'ChaosHideIntroMovie':				() => void,
 	'DemoPlaybackControl': 				(str: string, flt: float) => void,
 	'Drawer_ExtendAndNavigateToTab':	(tabid: string) => void,
 	'Drawer_NavigateToTab': 			(tabid: string) => void,


### PR DESCRIPTION
This is a dumb small change that adds the events present in `intro-movie.js`, but that aren't dumped by the game for some reason.