### PR TITLE
Add missing button types and GameStateAPI

### DIFF
--- a/p2ce/index.d.ts
+++ b/p2ce/index.d.ts
@@ -5,3 +5,11 @@
 
 /// <reference path="../shared/index.d.ts" />
 /// <reference path="./weapons.d.ts" />
+
+declare namespace GameStateAPI {
+	/** Returns true if this is a playtest build of P2CE */
+	function IsPlaytest(): boolean;
+
+	/** Returns true if the current playtest session is recording a demo */
+	function IsPlaytestRecording(): boolean;
+}

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -557,6 +557,9 @@ declare interface Panel {
 	UpdateCurrentAnimationKeyframes(animation: Keyframes): void;
 
 	UpdateFocusInContext(): boolean;
+
+	/** Check if this panel is still valid */
+	IsValid(): boolean;
 }
 
 declare interface Button extends Panel {
@@ -594,7 +597,40 @@ declare interface TextEntry extends Panel {
 declare interface ToggleButton extends Panel {
 	text: string;
 
-	SetSelected(arg0: boolean): void;
+	SetSelected(selected: boolean): void;
+}
+
+declare interface RadioButton extends Button {
+	group: string;
+
+	SetSelected(selected: boolean): void;
+
+	GetSelectedButton(): Panel;
+}
+
+/** A simple button type that contains a label */
+declare interface TextButton extends Button {
+	text: string;
+}
+
+declare interface NStateButton extends Button {
+	numstates: int32;
+
+	currentstate: int32;
+
+	/**
+	 * Increment the current state of the button
+	 * Wraps around to 0 when numstates+1 >= currentstate
+	 */
+	IncrementState(): void;
+
+	/**
+	 * Resets the current state to 0
+	 */
+	ResetState(): void;
+}
+
+declare interface HoldButton extends Button {
 }
 
 declare interface Frame extends Panel {


### PR DESCRIPTION
* Add interface definitions for the other built-in Panorama button types
* Add interface definitions for p2ce's `GameStateAPI` (I guess we missed this one)
* Add missing `IsValid()` method to `Panel`