### PR TITLE
feat: update zone defs to latest

### DIFF
--- a/momentum/index.d.ts
+++ b/momentum/index.d.ts
@@ -66,22 +66,15 @@ interface TrackZones extends JsonObject {
 	segments: Segment[];
 	end: Zone;
 }
-  
-interface TrackMovementParams extends JsonObject {
-	maxVelocity: number;
-	defragFlags: number;
-}
 
-interface TrackBase extends JsonObject {
+interface MainTrack extends JsonObject {
 	zones: TrackZones;
-	movementParams: TrackMovementParams;
-}
-
-interface MainTrack extends TrackBase {
 	stagesEndAtStageStarts: boolean;
 }
 
-interface BonusTrack extends TrackBase {
+interface BonusTrack extends JsonObject {
+	zones: TrackZones;
+	defragFlags: number;
 }
 
 interface MapTracks extends JsonObject {
@@ -92,6 +85,7 @@ interface MapTracks extends JsonObject {
 interface ZoneDef extends JsonObject {
 	formatVersion: number;
 	dataTimestamp: number;
+	maxVelocity: number;
 	tracks: MapTracks;
 }
   /**************************************************************************************************************/


### PR DESCRIPTION
This PR incorporates the following changes to zone definitions:

- Removed `TrackMovementParams`
- Moved max velocity property to map-level
- Bonus tracks can have zones OR defrag flags
- Main track and bonus tracks no longer inherit from `TrackBase`