### PR TITLE
feat: Add achievements API

### DIFF
--- a/p2ce/achievements.d.ts
+++ b/p2ce/achievements.d.ts
@@ -1,0 +1,52 @@
+
+interface Achievement {
+	name: string;						// Name of the achievement
+	index: number;						// Index of the achievement (for use with the API)
+	achieved: boolean;					// True if this has been achieved
+	available: boolean;					// True if this is available
+	hide_until_achieved: boolean;		// True if this is a "hidden" achievement. It should not be displayed in its full glory until achieved
+	flags: number;
+	count: number;						// Current count, if a stat is involved with this achievement. The achievement is granted when count >= goal
+	goal: number;						// Stat goal for this achievement
+}
+
+declare namespace AchievementsAPI {
+
+	/**
+	 * Returns true if cheats were turned on at any point during this session
+	 */
+	function HasCheated(): boolean;
+
+	/**
+	 * Returns the total number of achievements
+	 */
+	function GetAchievementCount(): number;
+
+	/**
+	 * Returns a description of the specified achievement
+	 * @param index Index of the achievement
+	 */
+	function GetAchievement(index: number): Achievement;
+
+	/**
+	 * Returns a complete list of all achievements. Shorthand for calling GetAchievement for each index
+	 */
+	function GetAchievements(): Array<Achievement>;
+
+	/**
+	 * Returns true if this achievement has been granted
+	 * @param index Achievement index
+	 */
+	function HasAchievement(index: number): boolean;
+
+	/**
+	 * Returns true if this achievement has been granted
+	 * @param name Name of the achievement
+	 */
+	function HasAchievementByName(name: string): boolean;
+
+	/**
+	 * Returns an array of achievement indices that have been achieved during this session of gameplay
+	 */
+	function GetAchievedDuringCurrentGame(): Array<number>;
+}

--- a/shared/events.d.ts
+++ b/shared/events.d.ts
@@ -86,4 +86,6 @@ interface GlobalEventNameMap {
 	'ShowVoteContextMenu':				() => void,
 	'StaticHudMenu_EntrySelected':		(panel: Panel) => void,
 	'UnloadLoadingScreenAndReinit':		() => void,
+	'AchievementInfoLoaded':			() => void,
+	'AchievementEarned':				(player_index: number, achievement_index: number) => void,
 }


### PR DESCRIPTION
The goal of this is to provide an API to query the status of achievements for display in the UI. Icons need to be handled on the UI side, since I don't think they should be baked into the code.