### PR TITLE
feat: remove momentum zone defs from types repo

### DIFF
--- a/momentum/index.d.ts
+++ b/momentum/index.d.ts
@@ -36,66 +36,6 @@ interface MapData {
 	credits: { type: string, user: { alias: string } }[];
 }
 
- /***************************************************************************************** */
-
-interface Region extends JsonObject {
-	points: Vec2D[];
-	bottom: number;
-	height: number;
-	teleDestTargetName: string; // mutually exclusive to other two teleport fields
-	teleDestPos: Vec3D; // TODO: This below are required if region is part of a volume used by stafe or major checkpoint zone
-	teleDestYaw: number; // See convo in mom red 25/09/23 02:00 GMT
-	safeHeight: number;
-}
-  
-interface Zone extends JsonObject {
-	regions: Region[];
-	filtername: string;
-}
-  
-interface Segment extends JsonObject {
-	limitStartGroundSpeed: boolean;
-	checkpointsRequired: boolean;
-	checkpointsOrdered: boolean;
-	checkpoints: Zone[];
-	cancel: Zone[];
-	name: string;
-}
-
-interface TrackZones extends JsonObject {
-	segments: Segment[];
-	end: Zone;
-}
-  
-interface TrackMovementParams extends JsonObject {
-	maxVelocity: number;
-	defragFlags: number;
-}
-
-interface TrackBase extends JsonObject {
-	zones: TrackZones;
-	movementParams: TrackMovementParams;
-}
-
-interface MainTrack extends TrackBase {
-	stagesEndAtStageStarts: boolean;
-}
-
-interface BonusTrack extends TrackBase {
-}
-
-interface MapTracks extends JsonObject {
-	main: MainTrack;
-	bonuses: BonusTrack[];
-}
-
-interface ZoneDef extends JsonObject {
-	formatVersion: number;
-	dataTimestamp: number;
-	tracks: MapTracks;
-}
-  /**************************************************************************************************************/
-
 declare type TimerEvent = TimerEventEnum[keyof TimerEventEnum];
 declare interface TimerEventEnum {
 	Started:     0,


### PR DESCRIPTION
This PR removes Momentum Mod new zone definitions. These zone defs are temporarily implemented in the panorama repo for Momentum Mod in the file `zoning.ts`