### PR TITLE
feat: 'MapLoaded', 'MapUnloaded' and 'Cancelled' events

### DIFF
--- a/shared/events.d.ts
+++ b/shared/events.d.ts
@@ -127,9 +127,10 @@ interface GlobalEventNameMap {
 	'SliderValueChanged':					(sourceID: string, value: float) => void,
 	'SpinnerValueChanged':					(sourceID: string, value: float) => void,
 	'ObserverTargetChanged':				(entIndex: int32) => void,
-	'MapLoaded':							(map_name: string, is_background: boolean) => void,
+	'MapLoaded':							(mapName: string, isBackgroundMap: boolean) => void,
 	'MapUnloaded':							() => void,
 	'Cancelled':							(sourceID: string, source: PanelEventSource) => void,
+	'PopulateLoadingScreen':				(mapName: string) => void,
 }
 
 /** Represents the info object provided by a DragEvent */

--- a/shared/events.d.ts
+++ b/shared/events.d.ts
@@ -127,6 +127,9 @@ interface GlobalEventNameMap {
 	'SliderValueChanged':					(sourceID: string, value: float) => void,
 	'SpinnerValueChanged':					(sourceID: string, value: float) => void,
 	'ObserverTargetChanged':				(entIndex: int32) => void,
+	'MapLoaded':							(map_name: string, is_background: boolean) => void,
+	'MapUnloaded':							() => void,
+	'Cancelled':							(sourceID: string, source: PanelEventSource) => void,
 }
 
 /** Represents the info object provided by a DragEvent */


### PR DESCRIPTION
These events are all defined in-engine. 'Cancelled' was removed at some point, probably because it looks like an event fired by JS.