### PR TITLE
Fix Momentum TS compilation

### DIFF
--- a/p2ce/events.d.ts
+++ b/p2ce/events.d.ts
@@ -5,4 +5,5 @@
 interface GlobalEventNameMap {
 	AchievementInfoLoaded:              () => void;
 	AchievementEarned:                  (player_index: number, achievement_index: number) => void;
+	GameSaved:							(save_name: string, save_type: SaveType) => void,
 }

--- a/shared/events.d.ts
+++ b/shared/events.d.ts
@@ -130,8 +130,7 @@ interface GlobalEventNameMap {
 	'MapLoaded':							(mapName: string, isBackgroundMap: boolean) => void,
 	'MapUnloaded':							() => void,
 	'Cancelled':							(sourceID: string, source: PanelEventSource) => void,
-	'PopulateLoadingScreen':				(mapName: string) => void,
-	'GameSaved':							(save_name: string, save_type: SaveType) => void,
+	'PopulateLoadingScreen':				(mapName: string) => void
 }
 
 /** Represents the info object provided by a DragEvent */


### PR DESCRIPTION
`SaveType` is defined in P2:CE-only files, so this breaks Momentum TS compiles. Please don't put P2CE stuff in `shared`!