### PR TITLE
feat: Add workshop GetAddonContributions function

### DIFF
--- a/p2ce/workshop.d.ts
+++ b/p2ce/workshop.d.ts
@@ -109,6 +109,9 @@ declare namespace WorkshopAPI {
 
 	/** Returns the download state of the addon at the specified index. */
 	function GetAddonState(index: uint32): DownloadState;
+
+	/** Returns the list of files currently being provided by the addon. Files overridden by other addons are not listed here. */
+	function GetAddonContributions(index: uint32): string[];
 }
 
 interface GlobalEventNameMap {


### PR DESCRIPTION
Adds a function to list the files currently being provided by a given addon.

```ts
const files = WorkshopAPI.GetAddonContributions(myAddonID);
// files = [
// "models/my_addon/test_model.mdl",
// "models/my_addon/test_model.vtx",
// "models/my_addon/test_model.vvd" ]
```